### PR TITLE
Move environmental variables to .env file

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,76 @@
+# The AI Application Gateway / Server configuration file
+export API_GATEWAY_CONFIG_FILE="./api-router-config.json"
+
+# The AI Application Gateway / Server listen port
+export API_GATEWAY_PORT=8000
+
+# The AI Application Gateway / Server deployment environment (e.g., dev, test, pre-prod, producution, etc.)
+export API_GATEWAY_ENV="dev"
+
+# The AI Application Gateway / Server log level - trace, debug, info, warn, fatal.
+export API_GATEWAY_LOG_LEVEL="info"
+
+# Secure Gateway APIs? [ "true" | "false" ]
+# DEFAULT: "true" (Secure the AI Application Gateway endpoints using Microsoft Entra ID)
+export API_GATEWAY_AUTH="true"
+
+# Azure Tenant ID
+export AZURE_TENANT_ID=""
+
+# Microsoft Entra API Gateway Client ID
+export API_GATEWAY_CLIENT_ID=""
+
+# AI Application Gateway Security Key.  This key is required for reconfiguring the AI Application Gateway.
+export API_GATEWAY_KEY=""
+
+#
+# Metrics collection variables
+#
+# Specify metrics collection interval in minutes
+export API_GATEWAY_METRICS_CINTERVAL=60
+
+# Specify the number of metrics collection buckets to save (in memory).
+# For instance, storing metrics for the past one week (24 * 7 = 168) 
+export API_GATEWAY_METRICS_CHISTORY=168
+
+# (Optional) Set this value to Azure Application Insights resource connection string
+export APPLICATION_INSIGHTS_CONNECTION_STRING=""
+
+# (Optional) Global setting - Use cached retrieval? (true / false)
+export API_GATEWAY_USE_CACHE="false"
+
+# (Optional) Cache entry invalidator run schedule (Cron schedule syntax)
+export API_GATEWAY_CACHE_INVAL_SCHEDULE="*/5 * * * *"
+
+# (Optional) Global setting - Use memory / state management? (true / false)
+export API_GATEWAY_STATE_MGMT="false"
+
+# (Optional) Memory entry invalidator run schedule (Cron schedule syntax)
+export API_GATEWAY_MEMORY_INVAL_SCHEDULE="*/5 * * * *"
+
+# (Optional) Global setting - Persist prompts in a DB? (true / false)
+export API_GATEWAY_PERSIST_PROMPTS="false"
+
+# AI Application that exposes vectorization model
+export API_GATEWAY_VECTOR_AIAPP="vectorizedata"
+
+# Search engine - only pgvector is supported!
+export API_GATEWAY_SRCH_ENGINE="Postgresql/pgvector"
+
+#
+# Vector Database configuration
+#
+# Vector Database connection string
+export VECTOR_DB_NAME="aoaisvc"
+
+# Vector Database host
+export VECTOR_DB_HOST="db.postgres.database.azure.com"
+
+# Vector Database user
+export VECTOR_DB_USER="user01"
+
+# Vector Database user password
+export VECTOR_DB_UPWD=""
+
+# Vector Database port
+export VECTOR_DB_PORT="5432"

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ Before we can get started, you will need a Linux Virtual Machine to run the AI A
    Set the environment variables to the correct values and export them before proceeding to the next step. Refer to the table below for descriptions of the environment variables.
 
    > **NOTE**:
-   > You can update and run the shell script `./set-api-gtwy-env.sh` to set and export the environment variables.
+   > You can source the shell script `. ./set-api-gtwy-env.sh` to read and export the environment variables contained in your .env file.
 
    Env Variable Name | Description | Required | Default Value
    ----------------- | ----------- | -------- | ------------- 
@@ -323,7 +323,7 @@ Before we can get started, you will need a Linux Virtual Machine to run the AI A
    API_GATEWAY_CLIENT_ID | When security is turned on for the gateway, this value is required. Specify the correct **Client ID** for the AI Application Gateway as defined in Application Registrations on Azure.  | No | None
    API_GATEWAY_METRICS_CINTERVAL | Backend API metrics collection and aggregation interval (in minutes) | Yes | Set it to a numeric value eg., 60 (1 hour)
    API_GATEWAY_METRICS_CHISTORY | Backend API metrics collection history count | Yes | Set it to a numeric value (<= 600)  
-   APPLICATIONINSIGHTS_CONNECTION_STRING | Azure Monitor connection string | No | Assign the value of the Azure Application Insights resource *connection string* (from Azure Portal)
+   APPLICATION_INSIGHTS_CONNECTION_STRING | Azure Monitor connection string | No | Assign the value of the Azure Application Insights resource *connection string* (from Azure Portal)
    API_GATEWAY_USE_CACHE | Global setting for enabling semantic caching feature. This setting applies to all AI Applications.| No | false
    API_GATEWAY_CACHE_INVAL_SCHEDULE | Global setting for configuring the frequency of *Cache Entry Invalidator* runs.  The schedule should be specified in *GNU Crontab* syntax. Refer to the docs [here](https://www.npmjs.com/package/node-cron). | No | "*/5 * * * *"
    API_GATEWAY_STATE_MGMT | Global setting for enabling conversational state management feature.  This setting applies to all AI Applications. | No | false

--- a/aoai-api-gtwy-chart/templates/deployment.yaml
+++ b/aoai-api-gtwy-chart/templates/deployment.yaml
@@ -55,7 +55,7 @@ spec:
               value: "{{ .Values.apigateway.metricsCInterval }}"
             - name: API_GATEWAY_METRICS_CHISTORY
               value: "{{ .Values.apigateway.metricsCHistory }}"
-            - name: APPLICATIONINSIGHTS_CONNECTION_STRING
+            - name: APPLICATION_INSIGHTS_CONNECTION_STRING
               value: "{{ .Values.apigateway.appInsightsConnectionString }}"
             - name: API_GATEWAY_USE_CACHE
               value: "{{ .Values.apigateway.useCache }}"

--- a/set-api-gtwy-env.sh
+++ b/set-api-gtwy-env.sh
@@ -1,59 +1,13 @@
-# The AI Application Gateway / Server configuration file
-export API_GATEWAY_CONFIG_FILE="./api-router-config.json"
-# The AI Application Gateway / Server listen port
-export API_GATEWAY_PORT=8000
-# The AI Application Gateway / Server deployment environment.  For instance, dev, test, pre-prod, producution ...
-export API_GATEWAY_ENV="dev"
-# The AI Application Gateway / Server log level - trace, debug, info, warn, fatal.
-export API_GATEWAY_LOG_LEVEL="info"
-
-# Secure Gateway APIs? [ "true" | "false" ]
-# DEFAULT: "true" (Secure the AI Application Gateway endpoints using Microsoft Entra ID)
-export API_GATEWAY_AUTH="true"
-# Azure Tenant ID
-export AZURE_TENANT_ID="[Specify Azure Tenant ID]"
-# Microsoft Entra API Gateway Client ID
-export API_GATEWAY_CLIENT_ID="[Specify Microsoft Entra AI Application Gateway Client ID]"
-
-# AI Application Gateway Security Key.  This key is required for reconfiguring the AI Application Gateway.
-export API_GATEWAY_KEY="abcxyz"
-
-# Metrics collection env variables
-
-# Specify metrics collection interval in minutes
-export API_GATEWAY_METRICS_CINTERVAL=60
-
-# Specify the number of metrics collection buckets to save (in memory).
-# For instance, the example below stores metrics for the past one week (24 * 7)
-export API_GATEWAY_METRICS_CHISTORY=168
-
-# (Optional) Set this value to Azure Application Insights resource connection string
-export APPLICATIONINSIGHTS_CONNECTION_STRING=""
-
-# (Optional) Global setting - Use cached retrieval? (true / false)
-export API_GATEWAY_USE_CACHE="false"
-
-# (Optional) Cache entry invalidator run schedule (Cron schedule syntax)
-export API_GATEWAY_CACHE_INVAL_SCHEDULE="*/5 * * * *"
-
-# (Optional) Global setting - Use memory / state management? (true / false)
-export API_GATEWAY_STATE_MGMT="false"
-
-# (Optional) Memory entry invalidator run schedule (Cron schedule syntax)
-export API_GATEWAY_MEMORY_INVAL_SCHEDULE="*/5 * * * *"
-
-# (Optional) Global setting - Persist prompts in a DB? (true / false)
-export API_GATEWAY_PERSIST_PROMPTS="false"
-
-# AI Application that exposes vectorization model
-export API_GATEWAY_VECTOR_AIAPP="vectorizedata"
-
-# Search engine - only pgvector is supported!
-export API_GATEWAY_SRCH_ENGINE="Postgresql/pgvector"
-
-# Vector DB host, port, name, uname and user pwd
-export VECTOR_DB_NAME="aoaisvc"
-export VECTOR_DB_HOST="db.postgres.database.azure.com"
-export VECTOR_DB_USER="user01"
-export VECTOR_DB_UPWD="semantic-cache"
-export VECTOR_DB_PORT="5432"
+# Check if .env file exists
+if [ -f .env ]; then
+  # Load environment variables from .env file
+  export $(cat .env | xargs)
+else
+  if [ -f .env.sample ]; then
+    # Copy .env.sample to .env
+    cp .env.sample .env
+    echo ".env file was missing, copied .env.sample to .env. Please modify the new .env file with the required environment variables and rerun."
+  else
+    echo ".env file is missing and .env.sample file is not available. Please create a .env file with the required environment variables."
+  fi
+fi

--- a/src/server.js
+++ b/src/server.js
@@ -124,7 +124,7 @@ async function readApiGatewayEnvVars() {
     process.exit(1);
   };
 
-  let azAppInsightsConString = process.env.APPLICATIONINSIGHTS_CONNECTION_STRING;
+  let azAppInsightsConString = process.env.APPLICATION_INSIGHTS_CONNECTION_STRING;
   if ( azAppInsightsConString ) {
     useAzureMonitor();
     wlogger.log({level: "info", message: "[%s] Azure Application Monitor OpenTelemetry configured.", splat: [scriptName]});


### PR DESCRIPTION
Moving to a .env file instead shell script allows for increased OS compatibility and prevent actual credentials from getting accidentally committed since .env files are ignored in this repo.