### PR TITLE
Fix typo introduced before commit

### DIFF
--- a/samples/python-basic/main.ipynb
+++ b/samples/python-basic/main.ipynb
@@ -36,7 +36,7 @@
     "client = AzureOpenAI(\n",
     "    api_key=AZURE_OAI_API_KEY,\n",
     "    api_version=azure_oai_api_version,\n",
-    "    azure_endpoint = os.getenv\n",
+    "    azure_endpoint = azure_oai_endpoint\n",
     "    )"
    ]
   },


### PR DESCRIPTION
Fix a spelling error introduced that didn't have the variable set and instead had a previously saved typo.